### PR TITLE
Added Traefik default network

### DIFF
--- a/example/docker-compose.yml
+++ b/example/docker-compose.yml
@@ -5,6 +5,7 @@ services:
     image: nginx:latest
     labels:
       - traefik.enable=true
+      - traefik.docker.network=indocker-app-network
       # https://doc.traefik.io/traefik/routing/providers/docker/#routers
       - traefik.http.routers.my-nginx-router.rule=Host(`my-nginx.indocker.app`)
       #- traefik.http.routers.my-nginx-router.entrypoints=https # "https" by default, but you can specify "http"
@@ -20,6 +21,7 @@ services:
     image: containous/whoami:latest
     labels:
       - traefik.enable=true
+      - traefik.docker.network=indocker-app-network
       - traefik.http.routers.whoami-router.rule=Host(`whoami.indocker.app`)
       - traefik.http.routers.whoami-router.entrypoints=http
       - traefik.http.routers.whoami-router.service=whoami-service

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -215,6 +215,7 @@ services:
     image: nginx:latest
     labels:
       - traefik.enable=true
+      - traefik.docker.network=indocker-app-network
       # https://doc.traefik.io/traefik/routing/providers/docker/#routers
       - traefik.http.routers.my-nginx-router.rule=Host(`my-nginx.indocker.app`)
       - traefik.http.routers.my-nginx-router.service=my-nginx-service
@@ -229,6 +230,7 @@ services:
     image: containous/whoami:latest
     labels:
       - traefik.enable=true
+      - traefik.docker.network=indocker-app-network
       - traefik.http.routers.whoami-router.rule=Host(`whoami.indocker.app`)
       - traefik.http.routers.whoami-router.entrypoints=http # force HTTP instead of HTTPS
       - traefik.http.routers.whoami-router.service=whoami-service

--- a/traefik/configs/traefik.yaml
+++ b/traefik/configs/traefik.yaml
@@ -45,4 +45,3 @@ providers:
     endpoint: 'unix:///var/run/docker.sock'
     watch: true
     exposedByDefault: false
-    network: indocker-app-network

--- a/traefik/configs/traefik.yaml
+++ b/traefik/configs/traefik.yaml
@@ -45,3 +45,4 @@ providers:
     endpoint: 'unix:///var/run/docker.sock'
     watch: true
     exposedByDefault: false
+    network: indocker-app-network


### PR DESCRIPTION
## Default Traefik network
Added default `network` in `traefik.yaml`:  
* When connecting multiple `network` you don’t have to write an additional `label` on the proxied container, because if you dont specify default network,  Traefik will not know on which network communicate with the container.
* This option you also can provide in `labels` of container, to which Traefik proxies ([docs](https://doc.traefik.io/traefik/providers/docker/#network)).

Unfortunately, it was not possible to test the correctness of the change, since Docker requires certificates for the indocker.app domain to build

Edited from Russian to English language.
